### PR TITLE
Bug-fixing and typo corrections.

### DIFF
--- a/code/hlp/Plexdata.LogWriter.help.shfbproj
+++ b/code/hlp/Plexdata.LogWriter.help.shfbproj
@@ -38,7 +38,7 @@
     <IndentHtml>False</IndentHtml>
     <BuildAssemblerVerbosity>OnlyWarningsAndErrors</BuildAssemblerVerbosity>
     <HelpTitle>Plexdata Logging Writer</HelpTitle>
-    <HelpFileVersion>1.0.2.6</HelpFileVersion>
+    <HelpFileVersion>1.0.2.7</HelpFileVersion>
     <NamingMethod>Guid</NamingMethod>
     <ContentPlacement>AboveNamespaces</ContentPlacement>
     <RootNamespaceContainer>True</RootNamespaceContainer>

--- a/code/hlp/Plexdata.LogWriter.wiki.shfbproj
+++ b/code/hlp/Plexdata.LogWriter.wiki.shfbproj
@@ -38,7 +38,7 @@
     <IndentHtml>False</IndentHtml>
     <BuildAssemblerVerbosity>OnlyWarningsAndErrors</BuildAssemblerVerbosity>
     <HelpTitle>Plexdata Logging Writer</HelpTitle>
-    <HelpFileVersion>1.0.2.6</HelpFileVersion>
+    <HelpFileVersion>1.0.2.7</HelpFileVersion>
     <NamingMethod>Guid</NamingMethod>
     <ContentPlacement>AboveNamespaces</ContentPlacement>
     <RootNamespaceContainer>True</RootNamespaceContainer>

--- a/code/src/HISTORY.md
+++ b/code/src/HISTORY.md
@@ -1,5 +1,12 @@
 
 
+**1.0.2.7**
+- Bugfix in `JsonFormatter`, re-escaping backslashes in any character escaping within double-quoted string value results.
+- Minor changes in exception handling in class `PersistentLoggerFacade`.
+- Correction of typos and documentation text adaptations.
+- Missing tests added and existing tests adjusted.
+- Version number increased.
+
 **1.0.2.6**
 - Persistent logger changes:
   - Support of auto-creation for non-existing folders.

--- a/code/src/Plexdata.LogWriter.Abstraction.Tests/Internals/Formatters/JsonFormatterTests.cs
+++ b/code/src/Plexdata.LogWriter.Abstraction.Tests/Internals/Formatters/JsonFormatterTests.cs
@@ -292,6 +292,21 @@ namespace Plexdata.LogWriter.Abstraction.Tests.Internals.Formatters
             Assert.That(actual, Is.EqualTo(String.Format(expected, message)));
         }
 
+        [Test]
+        public void Format_CheckCharacterEscaping_ResultIsExpectedCharacterEscaping()
+        {
+            String message = "\\ \" \r \n \f \t \b";
+            String expected = "{\"Key\":\"12345678-90AB-CDEF-1234-567890ABCDEF\",\"Time\":\"20191029170542\",\"Level\":\"MESSAGE\",\"Context\":null,\"Scope\":null,\"Message\":\"\\\\\\\\ \\\\\" \\\\r \\\\n \\\\f \\\\t \\\\b\",\"Details\":null,\"Exception\":null}";
+
+            this.value.SetupGet(x => x.Message).Returns(message);
+
+            this.instance.Format(this.builder, this.value.Object);
+
+            String actual = this.builder.ToString();
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
         #endregion
 
         #region Private helper methods

--- a/code/src/Plexdata.LogWriter.Abstraction.Tests/Properties/AssemblyInfo.cs
+++ b/code/src/Plexdata.LogWriter.Abstraction.Tests/Properties/AssemblyInfo.cs
@@ -55,5 +55,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.6")]
-[assembly: AssemblyFileVersion("1.0.2.6")]
+[assembly: AssemblyVersion("1.0.2.7")]
+[assembly: AssemblyFileVersion("1.0.2.7")]

--- a/code/src/Plexdata.LogWriter.Abstraction/Internals/Formatters/JsonFormatter.cs
+++ b/code/src/Plexdata.LogWriter.Abstraction/Internals/Formatters/JsonFormatter.cs
@@ -184,6 +184,7 @@ namespace Plexdata.LogWriter.Internals.Formatters
                 return $"\"{String.Empty}\"";
             }
 
+            // BUG: There is still a bug somewhere. The position of a backspace affects, but it shouldn't.
             value = value
                 .Replace("\\", "\\\\") // Replace backslash by escaped backslash.
                 .Replace("\"", "\\\"") // Replace double quote by escaped double quote.
@@ -191,7 +192,8 @@ namespace Plexdata.LogWriter.Internals.Formatters
                 .Replace("\n", "\\n")  // Replace line feed by escaped line feed.
                 .Replace("\f", "\\f")  // Replace form feed by escaped form feed.
                 .Replace("\b", "\\b")  // Replace backspace by escaped backspace.
-                .Replace("\t", "\\t"); // Replace tab by escaped tab.
+                .Replace("\t", "\\t")  // Replace tab by escaped tab.
+                .Replace("\\", "\\\\");// Re-escape any of already escaped backslashes (bugfix).
 
             return $"\"{value}\"";
         }

--- a/code/src/Plexdata.LogWriter.Abstraction/Plexdata.LogWriter.Abstraction.csproj
+++ b/code/src/Plexdata.LogWriter.Abstraction/Plexdata.LogWriter.Abstraction.csproj
@@ -14,10 +14,10 @@
 
 This package provides an implementation of an Empty logger as well, that might be useful as dummy or pre-logging implementation.</Description>
     <PackageTags>logging logger log trace debug raw structured abstraction</PackageTags>
-    <PackageReleaseNotes>No changes since last version.</PackageReleaseNotes>
-    <AssemblyVersion>1.0.2.6</AssemblyVersion>
-    <FileVersion>1.0.2.6</FileVersion>
-    <Version>1.0.2.6</Version>
+    <PackageReleaseNotes>Bugfix in 'JsonFormatter', re-escaping backslashes in any character escaping within double-quoted string value results.</PackageReleaseNotes>
+    <AssemblyVersion>1.0.2.7</AssemblyVersion>
+    <FileVersion>1.0.2.7</FileVersion>
+    <Version>1.0.2.7</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/code/src/Plexdata.LogWriter.Console.Standard/Plexdata.LogWriter.Console.Standard.csproj
+++ b/code/src/Plexdata.LogWriter.Console.Standard/Plexdata.LogWriter.Console.Standard.csproj
@@ -14,9 +14,9 @@ Main feature of this package is that it can be used platform independently.</Des
     <PackageIconUrl>https://github.com/akesseler/Plexdata.LogWriter/blob/master/icon.png?raw=true</PackageIconUrl>
     <PackageTags>logging logger log trace debug raw structured console standard</PackageTags>
     <PackageReleaseNotes>No changes since last version.</PackageReleaseNotes>
-    <AssemblyVersion>1.0.2.6</AssemblyVersion>
-    <FileVersion>1.0.2.6</FileVersion>
-    <Version>1.0.2.6</Version>
+    <AssemblyVersion>1.0.2.7</AssemblyVersion>
+    <FileVersion>1.0.2.7</FileVersion>
+    <Version>1.0.2.7</Version>
     <RootNamespace>Plexdata.LogWriter.Standard</RootNamespace>
   </PropertyGroup>
 

--- a/code/src/Plexdata.LogWriter.Console.Tests/Properties/AssemblyInfo.cs
+++ b/code/src/Plexdata.LogWriter.Console.Tests/Properties/AssemblyInfo.cs
@@ -55,5 +55,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.6")]
-[assembly: AssemblyFileVersion("1.0.2.6")]
+[assembly: AssemblyVersion("1.0.2.7")]
+[assembly: AssemblyFileVersion("1.0.2.7")]

--- a/code/src/Plexdata.LogWriter.Console.Windows/Plexdata.LogWriter.Console.Windows.csproj
+++ b/code/src/Plexdata.LogWriter.Console.Windows/Plexdata.LogWriter.Console.Windows.csproj
@@ -16,9 +16,9 @@
 Main feature of this package is that NOT only pure console applications are able to write logging messages into the console window. For example when using an old-fashioned Windows Forms application an extra window is opened that shows all logging messages.
 
 Attention: This package can only be used on Windows platforms because of it uses native Win32 API functions!</Description>
-    <AssemblyVersion>1.0.2.6</AssemblyVersion>
-    <FileVersion>1.0.2.6</FileVersion>
-    <Version>1.0.2.6</Version>
+    <AssemblyVersion>1.0.2.7</AssemblyVersion>
+    <FileVersion>1.0.2.7</FileVersion>
+    <Version>1.0.2.7</Version>
     <RootNamespace>Plexdata.LogWriter.Windows</RootNamespace>
   </PropertyGroup>
 

--- a/code/src/Plexdata.LogWriter.Console/Plexdata.LogWriter.Console.csproj
+++ b/code/src/Plexdata.LogWriter.Console/Plexdata.LogWriter.Console.csproj
@@ -14,9 +14,9 @@ This package includes classes that are shared between all available implementati
     <PackageIconUrl>https://github.com/akesseler/Plexdata.LogWriter/blob/master/icon.png?raw=true</PackageIconUrl>
     <PackageTags>logging logger log trace debug raw structured console</PackageTags>
     <PackageReleaseNotes>No changes since last version.</PackageReleaseNotes>
-    <AssemblyVersion>1.0.2.6</AssemblyVersion>
-    <FileVersion>1.0.2.6</FileVersion>
-    <Version>1.0.2.6</Version>
+    <AssemblyVersion>1.0.2.7</AssemblyVersion>
+    <FileVersion>1.0.2.7</FileVersion>
+    <Version>1.0.2.7</Version>
     <RootNamespace>Plexdata.LogWriter</RootNamespace>
   </PropertyGroup>
 

--- a/code/src/Plexdata.LogWriter.Help.Producer/Properties/AssemblyInfo.cs
+++ b/code/src/Plexdata.LogWriter.Help.Producer/Properties/AssemblyInfo.cs
@@ -55,5 +55,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.6")]
-[assembly: AssemblyFileVersion("1.0.2.6")]
+[assembly: AssemblyVersion("1.0.2.7")]
+[assembly: AssemblyFileVersion("1.0.2.7")]

--- a/code/src/Plexdata.LogWriter.Persistent.Tests/Facades/PersistentLoggerFacadeTests.cs
+++ b/code/src/Plexdata.LogWriter.Persistent.Tests/Facades/PersistentLoggerFacadeTests.cs
@@ -82,11 +82,10 @@ namespace Plexdata.LogWriter.Persistent.Tests.Facades
             Assert.That(() => this.instance.Write(this.filename, Encoding.ASCII, (String[])null), Throws.ArgumentNullException);
         }
 
-
         [Test]
         public void Write_AllMessagesAreInvalid_NothingIsWritten()
         {
-            List<String> messages = new List<String> { null, "", "   " };
+            List<String> messages = new List<String> { null, "", "   ", "\r\n" };
 
             Int64 expected = (new FileInfo(this.filename)).Length;
 

--- a/code/src/Plexdata.LogWriter.Persistent.Tests/Logging/PersistentLoggerBaseTests.cs
+++ b/code/src/Plexdata.LogWriter.Persistent.Tests/Logging/PersistentLoggerBaseTests.cs
@@ -51,7 +51,6 @@ namespace Plexdata.LogWriter.Persistent.Tests.Logging
         [SetUp]
         public void Setup()
         {
-
             this.settings = new Mock<IPersistentLoggerSettings>();
             this.facade = new Mock<IPersistentLoggerFacade>();
             this.scheduler = new Mock<IObservableQueue<String>>();

--- a/code/src/Plexdata.LogWriter.Persistent.Tests/Properties/AssemblyInfo.cs
+++ b/code/src/Plexdata.LogWriter.Persistent.Tests/Properties/AssemblyInfo.cs
@@ -55,5 +55,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.6")]
-[assembly: AssemblyFileVersion("1.0.2.6")]
+[assembly: AssemblyVersion("1.0.2.7")]
+[assembly: AssemblyFileVersion("1.0.2.7")]

--- a/code/src/Plexdata.LogWriter.Persistent.Tests/Settings/PersistentLoggerSettingsTests.cs
+++ b/code/src/Plexdata.LogWriter.Persistent.Tests/Settings/PersistentLoggerSettingsTests.cs
@@ -189,7 +189,7 @@ namespace Plexdata.LogWriter.Persistent.Tests.Settings
 
         [Test]
         [TestCaseSource(nameof(EncodingTestItemList))]
-        public void PersistentLoggerSettings_ConfigurationValid_GetSectionValueForEncodingAsExpected(Object current   /*String value, Object expected*/)
+        public void PersistentLoggerSettings_ConfigurationValid_GetSectionValueForEncodingAsExpected(Object current)
         {
             EncodingTestItem nominee = (EncodingTestItem)current;
 

--- a/code/src/Plexdata.LogWriter.Persistent/Facades/PersistentLoggerFacade.cs
+++ b/code/src/Plexdata.LogWriter.Persistent/Facades/PersistentLoggerFacade.cs
@@ -93,11 +93,11 @@ namespace Plexdata.LogWriter.Facades
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">
-        /// This exception is thrown if provided <paramref name="filename"/> 
+        /// This exception is thrown if provided parameter <paramref name="filename"/> 
         /// is <c>null</c>, <c>empty</c> or consists only of white spaces. 
         /// </exception>
         /// <exception cref="ArgumentNullException">
-        /// This exception is thrown if provided <paramref name="encoding"/> 
+        /// This exception is thrown if provided parameter <paramref name="encoding"/> 
         /// is <c>null</c>. 
         /// </exception>
         /// <seealso cref="IPersistentLoggerFacade.Write(String, Encoding, IEnumerable{String})"/>
@@ -109,12 +109,12 @@ namespace Plexdata.LogWriter.Facades
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">
-        /// This exception is thrown if provided <paramref name="filename"/> 
+        /// This exception is thrown if provided parameter <paramref name="filename"/> 
         /// is <c>null</c>, <c>empty</c> or consists only of white spaces. 
         /// </exception>
         /// <exception cref="ArgumentNullException">
-        /// This exception is thrown if provided <paramref name="encoding"/> is 
-        /// <c>null</c> or if provided <paramref name="messages"/> is <c>null</c>. 
+        /// This exception is thrown if provided parameter <paramref name="encoding"/> is 
+        /// <c>null</c> or if provided parameter <paramref name="messages"/> is <c>null</c>. 
         /// </exception>
         /// <exception cref="Exception">
         /// Other exceptions, such as <see cref="DirectoryNotFoundException"/>, 
@@ -147,7 +147,7 @@ namespace Plexdata.LogWriter.Facades
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">
-        /// This exception is thrown if provided <paramref name="filename"/> 
+        /// This exception is thrown if provided parameter <paramref name="filename"/> 
         /// is <c>null</c>, <c>empty</c> or consists only of white spaces. 
         /// </exception>
         /// <exception cref="Exception">

--- a/code/src/Plexdata.LogWriter.Persistent/Facades/PersistentLoggerFacade.cs
+++ b/code/src/Plexdata.LogWriter.Persistent/Facades/PersistentLoggerFacade.cs
@@ -114,7 +114,7 @@ namespace Plexdata.LogWriter.Facades
         /// </exception>
         /// <exception cref="ArgumentNullException">
         /// This exception is thrown if provided <paramref name="encoding"/> is 
-        /// <c>null</c> or if provided <paramref name="messages"/> are <c>null</c>. 
+        /// <c>null</c> or if provided <paramref name="messages"/> is <c>null</c>. 
         /// </exception>
         /// <exception cref="Exception">
         /// Other exceptions, such as <see cref="DirectoryNotFoundException"/>, 
@@ -134,7 +134,7 @@ namespace Plexdata.LogWriter.Facades
 
             if (encoding == null)
             {
-                throw new ArgumentNullException(nameof(encoding), "Encoding cannot be null.");
+                throw new ArgumentNullException(nameof(encoding), "The encoding cannot be null.");
             }
 
             if (messages == null)
@@ -223,7 +223,7 @@ namespace Plexdata.LogWriter.Facades
                     return true;
                 }
             }
-            catch (IOException)
+            catch (Exception)
             {
                 return false;
             }
@@ -274,7 +274,7 @@ namespace Plexdata.LogWriter.Facades
                     return true;
                 }
             }
-            catch (IOException)
+            catch (Exception)
             {
                 return false;
             }

--- a/code/src/Plexdata.LogWriter.Persistent/Logging/PersistentLoggerBase.cs
+++ b/code/src/Plexdata.LogWriter.Persistent/Logging/PersistentLoggerBase.cs
@@ -97,7 +97,9 @@ namespace Plexdata.LogWriter.Logging
         /// <param name="facade">
         /// The facade to be used.
         /// </param>
-        /// <param name="scheduler"></param>
+        /// <param name="scheduler">
+        /// The scheduler to be used.
+        /// </param>
         /// <exception cref="ArgumentNullException">
         /// This exception is thrown either if the <paramref name="settings"/> or the 
         /// <paramref name="facade"/> or the <paramref name="scheduler"/> is <c>null</c>.

--- a/code/src/Plexdata.LogWriter.Persistent/Plexdata.LogWriter.Persistent.csproj
+++ b/code/src/Plexdata.LogWriter.Persistent/Plexdata.LogWriter.Persistent.csproj
@@ -10,13 +10,14 @@
     <PackageProjectUrl>https://github.com/akesseler/Plexdata.LogWriter</PackageProjectUrl>
     <PackageIconUrl>https://github.com/akesseler/Plexdata.LogWriter/blob/master/icon.png?raw=true</PackageIconUrl>
     <PackageTags>logging logger log trace debug raw structured file persistent</PackageTags>
-    <PackageReleaseNotes>Persistent logger supports auto-creation of non-existing folders and a fallback folder if no directory is part of the filename. Property 'Filename' of persistent logger settings allows usage of environment variables.</PackageReleaseNotes>
+    <PackageReleaseNotes>- Minor changes in exception handling in class 'PersistentLoggerFacade'.
+- Correction of typos and documentation text adaptations.</PackageReleaseNotes>
     <Description>Plexdata.LogWriter.Persistent implements the IPersistentLogger interface that allows writing of logging messages into files.
 
 Main feature of this package is that it can be used platform independently.</Description>
-    <AssemblyVersion>1.0.2.6</AssemblyVersion>
-    <FileVersion>1.0.2.6</FileVersion>
-    <Version>1.0.2.6</Version>
+    <AssemblyVersion>1.0.2.7</AssemblyVersion>
+    <FileVersion>1.0.2.7</FileVersion>
+    <Version>1.0.2.7</Version>
     <RootNamespace>Plexdata.LogWriter</RootNamespace>
   </PropertyGroup>
 

--- a/code/src/Plexdata.LogWriter.Testing.Helper.Asp.Core/Plexdata.LogWriter.Testing.Helper.Asp.Core.csproj
+++ b/code/src/Plexdata.LogWriter.Testing.Helper.Asp.Core/Plexdata.LogWriter.Testing.Helper.Asp.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Version>1.0.2.6</Version>
+    <Version>1.0.2.7</Version>
     <Authors>plexdata.de</Authors>
     <Copyright>Copyright © 2019 - plexdata.de</Copyright>
   </PropertyGroup>

--- a/code/src/Plexdata.LogWriter.Testing.Helper.Net.Core/Plexdata.LogWriter.Testing.Helper.Net.Core.csproj
+++ b/code/src/Plexdata.LogWriter.Testing.Helper.Net.Core/Plexdata.LogWriter.Testing.Helper.Net.Core.csproj
@@ -7,9 +7,9 @@
     <Authors>plexdata.de</Authors>
     <Company>plexdata.de</Company>
     <Copyright>Copyright © 2019 - plexdata.de</Copyright>
-    <AssemblyVersion>1.0.2.6</AssemblyVersion>
-    <FileVersion>1.0.2.6</FileVersion>
-    <Version>1.0.2.6</Version>
+    <AssemblyVersion>1.0.2.7</AssemblyVersion>
+    <FileVersion>1.0.2.7</FileVersion>
+    <Version>1.0.2.7</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/code/src/Plexdata.LogWriter.Testing.Helper/Properties/AssemblyInfo.cs
+++ b/code/src/Plexdata.LogWriter.Testing.Helper/Properties/AssemblyInfo.cs
@@ -55,5 +55,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.6")]
-[assembly: AssemblyFileVersion("1.0.2.6")]
+[assembly: AssemblyVersion("1.0.2.7")]
+[assembly: AssemblyFileVersion("1.0.2.7")]

--- a/code/src/TODOs.md
+++ b/code/src/TODOs.md
@@ -1,6 +1,8 @@
 
 **TODOs**
 
+Recover release note of all packages every time them has been published on `nuget.org`.
+
 - Implement IEventLogger
   - A logger that writes into the event log (a distinction between windows and others is possibly necessary).
 - Implement IHttpLogger

--- a/code/src/WindowsFormsConsoleLoggerTestApplication/Properties/AssemblyInfo.cs
+++ b/code/src/WindowsFormsConsoleLoggerTestApplication/Properties/AssemblyInfo.cs
@@ -55,5 +55,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.6")]
-[assembly: AssemblyFileVersion("1.0.2.6")]
+[assembly: AssemblyVersion("1.0.2.7")]
+[assembly: AssemblyFileVersion("1.0.2.7")]

--- a/code/src/WindowsFormsConsoleLoggerTestApplication/WindowsFormsConsoleLoggerTestApplication.csproj
+++ b/code/src/WindowsFormsConsoleLoggerTestApplication/WindowsFormsConsoleLoggerTestApplication.csproj
@@ -119,10 +119,6 @@
       <Project>{e21853f7-2e58-465a-b235-eab4b762f584}</Project>
       <Name>Plexdata.LogWriter.Console</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Plexdata.LogWriter.Persistent\Plexdata.LogWriter.Persistent.csproj">
-      <Project>{b38da898-a77e-4988-bea0-5e69839d1499}</Project>
-      <Name>Plexdata.LogWriter.Persistent</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="main.ico" />


### PR DESCRIPTION
- Bugfix in `JsonFormatter`, re-escaping backslashes in any character escaping within double-quoted string value results.
- Minor changes in exception handling in class `PersistentLoggerFacade`.
- Correction of typos and documentation text adaptations.
- Missing tests added and existing tests adjusted.
- Version number increased.